### PR TITLE
fix: fixing the problem of the fast double clicking scrolling desalignment using button desabling and setTimeOut

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -236,7 +236,7 @@
       /* Setas de navegação */
       .arrow {
         position: absolute;
-        top: 70%;
+        top: 55%;
         border-radius: 25px;
         background-color: #e4cbb1;
         color: #c07809;

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -7,11 +7,28 @@ const nextBtn = document.getElementById("nextBtn");
 let scrollAmount = 0;
 const scrollStep = 270;
 
+prevBtn.disabled = false; //declare the prevBtn.disabled for use in disabling feature
+nextBtn.disabled = false;
+
 prevBtn.addEventListener("click", () => {
+  //left
   imagesContainer.scrollBy(-321, 0);
+  prevBtn.disabled = true; //disable the prevBtn for avoiding fast double click to cause the picture scrolling to desalign
+  nextBtn.disabled = true;
+  setTimeout(() => {
+    prevBtn.disabled = false; //reenable the prevBtn after 250ms
+    nextBtn.disabled = false;
+  }, 250);
 });
 nextBtn.addEventListener("click", () => {
+  //right
+  prevBtn.disabled = true;
+  nextBtn.disabled = true; //disable the nextBtn for avoiding fast double click to cause the picture scrolling to desalign
   imagesContainer.scrollBy(321, 0);
+  setTimeout(() => {
+    prevBtn.disabled = false;
+    nextBtn.disabled = false; //reenable the nextBtn after 250ms
+  }, 250);
 });
 
 //toggling the menu-icon


### PR DESCRIPTION
This pull request addresses the issue of fast double-clicking causing scrolling misalignment. The fix involves temporarily disabling the navigation buttons (previous and next) to prevent multiple rapid clicks from being registered. The buttons are re-enabled after a short delay using setTimeout, ensuring smooth scrolling without desynchronization. This solution improves user experience by preventing unwanted overlapping scroll actions when clicking too quickly.






